### PR TITLE
FileInfoCard Overflow Fix for Small Screens

### DIFF
--- a/lib/screens/dashboard/components/my_fields.dart
+++ b/lib/screens/dashboard/components/my_fields.dart
@@ -40,7 +40,7 @@ class MyFiles extends StatelessWidget {
         Responsive(
           mobile: FileInfoCardGridView(
             crossAxisCount: _size.width < 650 ? 2 : 4,
-            childAspectRatio: _size.width < 650 ? 1.3 : 1,
+            childAspectRatio: _size.width < 650 && _size.width > 350 ? 1.3 : 1,
           ),
           tablet: FileInfoCardGridView(),
           desktop: FileInfoCardGridView(


### PR DESCRIPTION
FileInfoCard overflow fixed, new condition added to child aspect ratio. When 350<screenWidth<650, card aspect ratio 1.3, in other cases aspect ratio 1 like square. 