### PR TITLE
Fixed a scrolling bug

### DIFF
--- a/lib/screens/dashboard/dashboard_screen.dart
+++ b/lib/screens/dashboard/dashboard_screen.dart
@@ -13,6 +13,7 @@ class DashboardScreen extends StatelessWidget {
   Widget build(BuildContext context) {
     return SafeArea(
       child: SingleChildScrollView(
+        controller: ScrollController(),
         padding: EdgeInsets.all(defaultPadding),
         child: Column(
           children: [

--- a/lib/screens/main/components/side_menu.dart
+++ b/lib/screens/main/components/side_menu.dart
@@ -10,6 +10,7 @@ class SideMenu extends StatelessWidget {
   Widget build(BuildContext context) {
     return Drawer(
       child: ListView(
+        controller: ScrollController(),
         children: [
           DrawerHeader(
             child: Image.asset("assets/images/logo.png"),


### PR DESCRIPTION
When scrolling with a small size screen, neither the side menu scroll bar nor the main page scroll bar are shown. And the following assertion was thrown while notifying status listeners for AnimationController: The provided ScrollController is currently attached to more than one ScrollPosition.