### PR TITLE
bugfix: ScrollController error because of scroll multiple elements

### DIFF
--- a/lib/screens/dashboard/dashboard_screen.dart
+++ b/lib/screens/dashboard/dashboard_screen.dart
@@ -13,6 +13,7 @@ class DashboardScreen extends StatelessWidget {
   Widget build(BuildContext context) {
     return SafeArea(
       child: SingleChildScrollView(
+        primary: false,
         padding: EdgeInsets.all(defaultPadding),
         child: Column(
           children: [


### PR DESCRIPTION
Multiple scroll elements were causing the ScrollController error  like
"The provided ScrollController is currently attached to more than one ScrollPosition"

https://stackoverflow.com/questions/71305700/flutter-web-showing-error-for-scrollposition/71305907#71305907

Check this for more details. Thank you